### PR TITLE
working jest vs mocha expect

### DIFF
--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["mocha"]
+  }
+}

--- a/test/unit/app.spec.ts
+++ b/test/unit/app.spec.ts
@@ -1,5 +1,6 @@
-import {App} from '../../src/app';
-declare let expect: any;
+/// <reference types="jest" />
+
+import { App } from '../../src/app';
 describe('the app', () => {
   it('says hello', () => {
     expect(new App().message).toBe('Hello World!');

--- a/test/unit/tsconfig.json
+++ b/test/unit/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
- for #1 

So the only surprising solution I have found

- has separate `tsconfig.json` in test/unit and test/e2e folders. 
- adds `/// <reference types="jest" />` comment to each unit spec file

I don't know why listing explicitly `jest` as a type in `test/unit/tsconfig.json` does not generate the same result. Or why the file `test/unit/tsconfig.json` is even necessary for this to work - without this dummy file I could not get expect from `jest` to work!

<img width="695" alt="screen shot 2019-01-16 at 9 38 13 pm" src="https://user-images.githubusercontent.com/2212006/51292090-a3e70480-19d7-11e9-8bc7-a79d7c54de87.png">
